### PR TITLE
Smooth-sloped settlement display

### DIFF
--- a/settlements.civmap.json
+++ b/settlements.civmap.json
@@ -10,19 +10,20 @@
             "name": "Settlements",
             "style_base": {
                 "color": {
-                    "default": "#888888",
+                    "default": "#ffcc77",
                     "feature_key": "Zoom Visibility",
                     "categories": {
-                        "1": "#ffcc77",
-                        "2": "#ffcc77"
                     }
                 },
                 "icon_size": {
-                    "default": 12,
+                    "default": 8,
                     "feature_key": "Zoom Visibility",
                     "categories": {
-                        "1": 16,
-                        "2": 16
+                        "1": 18,
+                        "2": 16,
+                        "3": 14,
+                        "4": 12,
+                        "5": 10
                     }
                 },
                 "icon": "circle",
@@ -30,11 +31,9 @@
                 "opacity": 0,
                 "stroke_color": "#000000",
                 "stroke_width": {
-                    "default": 1,
+                    "default": 2,
                     "feature_key": "Zoom Visibility",
                     "categories": {
-                        "1": 2,
-                        "2": 2
                     }
                 }
             },


### PR DESCRIPTION
Two changes:
- Made all settlements display as #ffcc77 (no more #888888)
- Made each visibility level smaller than the last
I propose this change because it gives us more to work with in terms of settlement visibility levels. The color change was giving unnecessary meaning to the 2-3 transition, and indicated that any settlement below visibility 3 is dead, which is obviously wrong. It was making a statement that we didn't want to make. Having all settlements, from Icenia City to some three-years-dead shitter outpost, be the same color removes the color as a variable and as a statement. In its place, I make something more gradated and even: a steady decline in dot size, from rather large dots at 1 to very small dots at 5. Simpler, clearer, and more manageable.