### PR TITLE
Create dereliction.json

### DIFF
--- a/dereliction.json
+++ b/dereliction.json
@@ -1,0 +1,40 @@
+{
+	"info": { "version": "3.0.0-beta3", "last_update": 1628353970 },
+	"name": "Dereliction Requests",
+	"collectionId": "ccmap/ump/exclusion_zones",
+	"presentations": [
+		{
+			"name": "Dereliction Requests",
+			"style_base": {
+				"color": "$color|#ffff00",
+				"fill_pattern": "yellow_stripes",
+				"fill_opacity": 0.7,
+				"opacity": 0.7,
+				"label": null,
+				"stroke_width": 0
+			},
+			"style_highlight": {
+				"opacity": 1,
+				"fill_opacity": 1,
+				"label": "[Dereliction]\nBy: $madeby\nExpires: $dateofexpiration\nReason: $reason",
+				"stroke_color": "#ffff00",
+				"stroke_width": 0
+			},
+			"zoom_styles": {
+				"-1": {
+					"label": null
+				}
+			}
+		}
+	],
+	"features": [
+		{
+			"target": "Armenia",
+			"madeby": "K0mmi",
+			"dateofexpiration": "8-14-2021",
+			"reason": "Completely inactive for months",
+			"id": "faf6775f-602e-43d3-b754-9c25e0ef9433",
+			"polygon": [[[-8645,-1800],[-8761,-1736],[-8873,-1644],[-8985,-1516],[-9001,-1428],[-9161,-1372],[-9185,-1188],[-9001,-740],[-8977,-480],[-8845,-448],[-8837,-348],[-8821,-312],[-8753,-332],[-8705,-412],[-8633,-376],[-8281,-313],[-8342,-530],[-8407,-602],[-8445,-635],[-8407,-680],[-8338,-698],[-8298,-686],[-8268,-747],[-8323,-805],[-8298,-897],[-8205,-972],[-8113,-1072],[-8057,-1108],[-8001,-1160],[-7881,-1284],[-7837,-1300],[-7841,-1384],[-7953,-1388],[-8013,-1460],[-8089,-1428]]]
+		}
+	]
+}

--- a/dereliction.json
+++ b/dereliction.json
@@ -1,7 +1,7 @@
 {
 	"info": { "version": "3.0.0-beta3", "last_update": 1628353970 },
 	"name": "Dereliction Requests",
-	"collectionId": "ccmap/ump/exclusion_zones",
+	"collectionId": "ccmap/ump/dereliction",
 	"presentations": [
 		{
 			"name": "Dereliction Requests",
@@ -16,7 +16,7 @@
 			"style_highlight": {
 				"opacity": 1,
 				"fill_opacity": 1,
-				"label": "[Dereliction]\nBy: $madeby\nExpires: $dateofexpiration\nReason: $reason",
+				"label": "[Dereliction]",
 				"stroke_color": "#ffff00",
 				"stroke_width": 0
 			},
@@ -29,11 +29,11 @@
 	],
 	"features": [
 		{
-			"target": "Armenia",
-			"madeby": "K0mmi",
-			"dateofexpiration": "8-14-2021",
-			"reason": "Completely inactive for months",
-			"id": "faf6775f-602e-43d3-b754-9c25e0ef9433",
+			"Target": "Armenia",
+			"Made by": "K0mmi",
+			"Date of Expiration": "2021-08-14",
+			"Reason": "Completely inactive for months",
+			"id": "eaf6775f-602e-43d3-b754-9c25e0ef9433",
 			"polygon": [[[-8645,-1800],[-8761,-1736],[-8873,-1644],[-8985,-1516],[-9001,-1428],[-9161,-1372],[-9185,-1188],[-9001,-740],[-8977,-480],[-8845,-448],[-8837,-348],[-8821,-312],[-8753,-332],[-8705,-412],[-8633,-376],[-8281,-313],[-8342,-530],[-8407,-602],[-8445,-635],[-8407,-680],[-8338,-698],[-8298,-686],[-8268,-747],[-8323,-805],[-8298,-897],[-8205,-972],[-8113,-1072],[-8057,-1108],[-8001,-1160],[-7881,-1284],[-7837,-1300],[-7841,-1384],[-7953,-1388],[-8013,-1460],[-8089,-1428]]]
 		}
 	]


### PR DESCRIPTION
There. This won't fix all claim housekeeping debates (you could have a super dead claim whose supposed owner keeps sniping the dereliction request ig), but hopefully this will cut down on the unnecessary vitrol and accusations of bias.

This won't work until CivMap/app/js/utils/presentation.js gets updated with yellow_lines. Do not merge this until that happens.