### PR TITLE
Settlements: Fix image for Gondolin

### DIFF
--- a/settlements.civmap.json
+++ b/settlements.civmap.json
@@ -2481,7 +2481,7 @@
             "z": -9000,
             "nation": "Gondolin Ascendancy (Varkonia)",
             "contact": "Seldomshock#2199",
-            "image": "https://cdn.discordapp.com/attachments/812188404028669972/846453844816298044/2020-08-08_15.29.02.png",
+            "image": "https://static.miraheze.org/civwikiwiki/4/40/Gondolin.png",
             "discord": "https://discord.gg/JsFvya8Cpz",
             "wiki": "https://civwiki.org/wiki/Gondolin",
             "visitors": "welcome",


### PR DESCRIPTION
Hotlinks to discord images are broken nowadays. I just fixed the one I saw, because I wanted to look at a picture of Gondolin.